### PR TITLE
Replace `unreachable!` panics with errors

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -18,10 +18,12 @@ pub enum ResourceType {
     TableLibrary = 0x0203,
 }
 
-impl From<u16> for ResourceType {
-    fn from(bits: u16) -> Self {
+impl TryFrom<u16> for ResourceType {
+    type Error = std::io::Error;
+
+    fn try_from(bits: u16) -> Result<Self, Self::Error> {
         use ResourceType::*;
-        match bits {
+        Ok(match bits {
             0 => Null,
             1 => StringPool,
             2 => Table,
@@ -29,8 +31,13 @@ impl From<u16> for ResourceType {
             0x0201 => TableType,
             0x0202 => TableTypeSpec,
             0x0203 => TableLibrary,
-            bits => unreachable!("Unexpected bits: {bits}"),
-        }
+            bits => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Unexpected bits: {bits}"),
+                ));
+            }
+        })
     }
 }
 

--- a/src/parser/components_read.rs
+++ b/src/parser/components_read.rs
@@ -11,7 +11,7 @@ impl<R: Read> TryFrom<&mut BufReader<R>> for Header {
 
     fn try_from(reader: &mut BufReader<R>) -> Result<Self, Self::Error> {
         let type_bits = read_util::read_u16(reader)?;
-        let r#type = ResourceType::from(type_bits);
+        let r#type = ResourceType::try_from(type_bits)?;
         let header_size = read_util::read_u16(reader)?;
         let size = read_util::read_u32(reader)? as u64;
         Ok(Header {

--- a/src/parser/components_read.rs
+++ b/src/parser/components_read.rs
@@ -295,7 +295,12 @@ impl<R: Read + Seek> TryFrom<&mut BufReader<R>> for Package {
                     config.header_size = header.header_size;
                     types[config.type_id - 1].configs.push(config);
                 }
-                flag => unreachable!("Unexpected flag: {flag:?}"),
+                flag => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Unexpected flag: {flag:?}"),
+                    ))
+                }
             }
         }
         Ok(Package {


### PR DESCRIPTION
### Changes
- Replaces `From<u16>` implementation of `ResourceType` with `TryFrom` which returns a `std::io::Error` representing `InvalidData` and wrapping the panic message.
- Returns a similar `InvalidData` variant of `std::io::Error` for unknown flags.